### PR TITLE
configurable mqtt_username/mqtt_password

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ In a Python 3 virtual env, do:
 $ python -m pip install esptool adafruit-ampy requests click
 ```
 
+On Ubuntu install:
+
+```bash
+sudo apt-get install python3-pip python3-requests python3-click
+pip3 install esptool adafruit-ampy ampy
+```
+
 Then, run `python flash-me.py mqtt` to flash the robot.
 
 This uploads both firmware and Python modules.
@@ -38,6 +45,10 @@ you can pass `-X` to only update the Python modules.
 ## HOW TO: connect to terminal
 
  * Open terminal (Putty, Picocom, Minicom or whatever). speed: 115200
+
+```bash
+minicom -D /dev/ttyUSB0
+```
 
  * Press `Ctrl+C` to stop running Python code. Prompt `>>>` should appear.
 

--- a/config.py.example
+++ b/config.py.example
@@ -2,4 +2,7 @@ wifi_essid = 'robot'
 wifi_password = 'secret123secret'
 
 mqtt_host = 'broker.hivemq.com'
+#mqtt_user = 'guest'
+#mqtt_password = 'guest'
+
 robot_name = 'Test robot'

--- a/mqtt/client.py
+++ b/mqtt/client.py
@@ -42,7 +42,7 @@ def intro():
     time.sleep(0.5)
 
 
-def mqtt_drive(server="localhost", robot_name='robot'):
+def mqtt_drive(server="localhost", robot_name='another robot', mqtt_user='guest', mqtt_password='guest'):
     global time_to_stop
 
     intro()
@@ -54,7 +54,7 @@ def mqtt_drive(server="localhost", robot_name='robot'):
 
     time_to_announce = ticks_ms() + 15 * 1000
 
-    c = MQTTClient(b"umqtt_client/%s" % robot_id, server)
+    c = MQTTClient(b"umqtt_client/%s" % robot_id, server, 1883, mqtt_user, mqtt_password)
     c.set_callback(msg_callback)
     #    c.set_last_will(topic + "/$online$", "0", retain=1)
     c.connect()

--- a/mqtt/main.py
+++ b/mqtt/main.py
@@ -6,9 +6,17 @@ try:
 except ImportError:
     mqtt_host = 'broker.hivemq.com'
 try:
+    from config import mqtt_user
+except ImportError:
+    mqtt_user = 'guest'
+try:
+    from config import mqtt_password
+except ImportError:
+    mqtt_password = 'guest'
+try:
     from config import robot_name
 except ImportError:
     robot_name = 'another robot'
 
 wifi_connect.connect()
-client.mqtt_drive(mqtt_host, robot_name=robot_name)
+client.mqtt_drive(mqtt_host, robot_name=robot_name, mqtt_user=mqtt_user, mqtt_password=mqtt_password)


### PR DESCRIPTION
This change is required if you like to have your private MQTT server protected by password. For example if you are running RabbitMQ server on Raspberry Pi.

https://github.com/lhost/rpi-scripts/blob/8052cf35679b666d6e5c4c1a6d7e145eb03a6797/nodemcu-webdriver.sh#L16
